### PR TITLE
Make the grammar PCRE compatible

### DIFF
--- a/ABL.YAML-tmLanguage
+++ b/ABL.YAML-tmLanguage
@@ -21,7 +21,7 @@ patterns:
     end: \"(?!\")
     patterns:
       - name: constant.character.escape.abl
-        match: (~(x[0-9A-Fa-f]{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)|\"\")
+        match: (~(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)|\"\")
 
   - name: constant.numeric.source.abl
     match: (?<!\w)((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?))

--- a/ABL.YAML-tmLanguage
+++ b/ABL.YAML-tmLanguage
@@ -21,7 +21,7 @@ patterns:
     end: \"(?!\")
     patterns:
       - name: constant.character.escape.abl
-        match: (~(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)|\"\")
+        match: (~(x[0-9A-Fa-f]{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)|\"\")
 
   - name: constant.numeric.source.abl
     match: (?<!\w)((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?))

--- a/ABL.tmLanguage
+++ b/ABL.tmLanguage
@@ -43,7 +43,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(~(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)|\"\")</string>
+					<string>(~(x[0-9A-Fa-f]{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)|\"\")</string>
 					<key>name</key>
 					<string>constant.character.escape.abl</string>
 				</dict>

--- a/ABL.tmLanguage
+++ b/ABL.tmLanguage
@@ -43,7 +43,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(~(x[0-9A-Fa-f]{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)|\"\")</string>
+					<string>(~(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)|\"\")</string>
 					<key>name</key>
 					<string>constant.character.escape.abl</string>
 				</dict>


### PR DESCRIPTION
This pull request changes 1 regular expressions in an attempt to make the grammar PCRE-compatible. While Atom uses an Oniguruma engine, github.com (which rely on this grammar for YAML highlighting) uses a PCRE-based engine. The two engines interpret `\h` differently, and only Oniguruma engines support implicit count modifiers (`{,n}`).